### PR TITLE
wsp: Select item under pointer on initial show

### DIFF
--- a/src/windowSwitcherPopup.js
+++ b/src/windowSwitcherPopup.js
@@ -531,6 +531,25 @@ export const WindowSwitcherPopup = {
         }
     },
 
+    _getIndexUnderPointer() {
+        if (!this._switcherList || !this._switcherList.visible)
+            return -1;
+
+        const [pointerX, pointerY] = global.get_pointer();
+        const [hasPoint, localX, localY] = this._switcherList.transform_stage_point(pointerX, pointerY);
+        if (!hasPoint)
+            return -1;
+
+        for (let i = 0; i < this._switcherList._items.length; i++) {
+            const item = this._switcherList._items[i];
+            const box = item.get_allocation_box();
+            if (localX >= box.x1 && localX <= box.x2 && localY >= box.y1 && localY <= box.y2)
+                return i;
+        }
+
+        return -1;
+    },
+
     _setInitialSelection(backward) {
         const recentWindow = Util.getWindows(null)[0];
         if (this._searchQuery) {
@@ -566,6 +585,14 @@ export const WindowSwitcherPopup = {
 
         if (this._items.length === 1 && this._switcherList) {
             this._select(0);
+            return;
+        }
+
+        // Prefer seamless mouse-driven selection when the pointer already hovers an item
+        const pointerIndex = this._getIndexUnderPointer();
+        if (pointerIndex > -1) {
+            this._mouseHoveringItemIndex = pointerIndex;
+            this._select(pointerIndex);
             return;
         }
 


### PR DESCRIPTION
Hi! Thanks for your project so much!

When the switcher opens today, even if I already have the cursor resting on a window thumbnail, the UI still highlights the previously focused window. That means I have to nudge the mouse just to get back to the item I visibly hovered over- a small but annoying hitch when switching with the mouse involved. 

This change looks at the pointer position during the initial selection phase and, if it’s already over one of the tiles, highlights that entry immediately. The result is that the popup feels consistent with what you see under the pointer: Alt‑Tab, glance at the item you want (or keep your cursor parked there between switches), and the very first selection already matches it.