### PR TITLE
feat!: GNOME Shell 50 modal grab, switcher show lock, and prefs UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Errors when toggling sticky and above on app
 - Mode indicator in the status label
 - Access to undefined this._favoritesFull
+- Extension preferences not reopening reliably: clear reused preference pages and avoid stacking `close-request` handlers on `AdwPreferencesWindow`
 
 
 ### v49.0 (2025-09-25)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ An extension for GNOME Shell that enhances its following built-in switchers:
 ![Window Switcher Popup](screenshots/screenshot.png)
 
 ## Features:
-- Supports GNOME Shell 42 - 50 (legacy versions also available for 3.36 - 41)
+- Supports GNOME Shell 42 - **50** (legacy versions also available for 3.36 - 41). GNOME Shell **50** is **Wayland-only**; after install or update, use a full **Log Out / Log In** so Shell loads the extension ([see below](#gnome-shell-50)).
 - Filters (all/workspace/monitor), sorting, grouping options, most of them switchable *on the fly*
 - Type to search - windows, apps, settings. Search can automatically switch current filter mode if needed
 - Hotkeys allow to control switcher and windows, including relocations
@@ -29,7 +29,7 @@ An extension for GNOME Shell that enhances its following built-in switchers:
 - Mouse control, including optional top or bottom hot edge for switcher activation
 - Configurable mouse buttons and scroll wheel
 - Supported by the *Custom Hot Corners - Extended* extension
-- Workspace Thumbnails option allows better navigation between workspaces (GNONE 40+)
+- Workspace Thumbnails option allows better navigation between workspaces (GNOME 40+)
 
 [Video review on Linux Experience Youtube channel](https://youtu.be/KtjYPMCvQ7Y?t=447)
 
@@ -117,6 +117,13 @@ Run following commands in the terminal (`git` needs to installed, navigate to th
     cd advanced-alttab-window-switcher/
     make install
 
+#### GNOME Shell 50
+
+The same `main` branch and `make install` steps as for **GNOME 45+** apply. GNOME Shell 50 drops the X11 session, so there is no `Alt`+`F2` `r` full-shell restart.
+
+- After installing or updating from a zip, `make install`, or copying files into `~/.local/share/gnome-shell/extensions/`, **log out and log back in** (or reboot). Shell only rescans user extensions at session start; until then, the extension may not appear in **Extensions** or `gnome-extensions list`, and toggling the switch may not load new code reliably.
+- Preferences use **libadwaita** / **GTK 4** APIs current in GNOME 50; use the **Extensions** app or `gnome-extensions prefs advanced-alt-tab@G-dH.github.com` to open settings.
+
 #### GNOME 42 - 44
 
     git clone https://github.com/G-dH/advanced-alttab-window-switcher.git
@@ -134,7 +141,7 @@ Run following commands in the terminal (`git` needs to installed, navigate to th
 ### Enable installed extension
 After installation you need to enable the extension. Only direct installation from extension.gnome.org loads the code and enables the extension immediately.
 
-- First restart GNOME Shell (`ALt` + `F2`, `r`, `Enter`, or Log Out/Log In if you use Wayland)
+- Restart the session so GNOME Shell loads the extension: on **X11** (Shell 42–49, if you use the X11 session) you can press `Alt`+`F2`, type `r`, and press `Enter`. On **Wayland**, and on **GNOME Shell 50** (Wayland only), use **Log Out** / **Log In** (or reboot).
 - Now you should see the new extension in *Extensions* (or *GNOME Tweak Tool* on older systems) application (reopen the app if needed to load new data), where you can enable it and access its Preferences/Settings.
 - You can also enable the extension from the command line:
 

--- a/extension.js
+++ b/extension.js
@@ -85,8 +85,9 @@ export default class AATWS extends Extension {
         Main.layoutManager.aatws = null;
 
         if (this._overrides) {
-            this._overrides.removeOverride('WindowSwitcherPopup');
+            this._overrides.removeOverride('AppSwitcherPopupInit');
             this._overrides.removeOverride('AppSwitcherPopup');
+            this._overrides.removeOverride('WindowSwitcherPopup');
         }
         this._overrides = null;
 
@@ -103,7 +104,7 @@ export default class AATWS extends Extension {
         this._opt = null;
         this.Me = null;
 
-        console.debug(`${this.metadata.name}: enabled`);
+        console.debug(`${this.metadata.name}: disabled`);
     }
 
     _updateSettings(settings, key) {

--- a/prefs.js
+++ b/prefs.js
@@ -48,6 +48,20 @@ function _getActionList() {
 
 
 export default class AATWS extends ExtensionPreferences {
+    _prefsWindow = null;
+    _prefsCloseRequestId = 0;
+
+    _clearPreferencesWindowPages(window) {
+        if (!window?.get_visible_page || !window.remove)
+            return;
+        for (let n = 0; n < 64; n++) {
+            const page = window.get_visible_page();
+            if (!page)
+                break;
+            window.remove(page);
+        }
+    }
+
     _getPageList() {
         const itemFactory = new OptionsFactory.ItemFactory(this.opt);
         const options = this._getOptions(itemFactory);
@@ -99,6 +113,18 @@ export default class AATWS extends ExtensionPreferences {
     }
 
     async fillPreferencesWindow(window) {
+        if (this._prefsCloseRequestId && this._prefsWindow) {
+            try {
+                this._prefsWindow.disconnect(this._prefsCloseRequestId);
+            } catch (e) {
+                /* window may already be destroyed */
+            }
+            this._prefsCloseRequestId = 0;
+            this._prefsWindow = null;
+        }
+
+        this._clearPreferencesWindowPages(window);
+
         try {
             const Me = {
                 metadata: this.metadata,
@@ -116,7 +142,9 @@ export default class AATWS extends ExtensionPreferences {
             else
                 window.search_enabled = true;
             window.set_default_size(840, 800);
-            window.connect('close-request', () => {
+
+            this._prefsWindow = window;
+            this._prefsCloseRequestId = window.connect('close-request', () => {
                 this.opt?.destroy();
                 this.opt = null;
             });

--- a/prefs.js
+++ b/prefs.js
@@ -98,24 +98,31 @@ export default class AATWS extends ExtensionPreferences {
         return pageList;
     }
 
-    fillPreferencesWindow(window) {
-        const Me = {
-            metadata: this.metadata,
-            gSettings: this.getSettings(),
-            _: this.gettext.bind(this),
-        };
-        Me.opt = new Settings.Options(Me);
+    async fillPreferencesWindow(window) {
+        try {
+            const Me = {
+                metadata: this.metadata,
+                gSettings: this.getSettings(),
+                _: this.gettext.bind(this),
+            };
+            Me.opt = new Settings.Options(Me);
 
-        this.opt = Me.opt;
-        _ = Me._;
+            this.opt = Me.opt;
+            _ = Me._;
 
-        OptionsFactory.AdwPrefs.getFilledWindow(window, this._getPageList());
-        window.set_search_enabled(true);
-        window.set_default_size(840, 800);
-        window.connect('close-request', () => {
-            this.opt.destroy();
-            this.opt = null;
-        });
+            OptionsFactory.AdwPrefs.getFilledWindow(window, this._getPageList());
+            if (window.set_search_enabled)
+                window.set_search_enabled(true);
+            else
+                window.search_enabled = true;
+            window.set_default_size(840, 800);
+            window.connect('close-request', () => {
+                this.opt?.destroy();
+                this.opt = null;
+            });
+        } catch (err) {
+            console.error(`[${this.metadata.name}]`, err);
+        }
     }
 
     _getCommonOptionList(options) {

--- a/src/optionsFactory.js
+++ b/src/optionsFactory.js
@@ -372,27 +372,15 @@ export const AdwPrefs = class {
                 continue;
             }
 
-            const row = new Adw.ActionRow({
-                title: option._title,
-            });
-
-            const grid = new Gtk.Grid({
-                column_homogeneous: false,
-                column_spacing: 20,
-                margin_start: 8,
-                margin_end: 8,
-                margin_top: 8,
-                margin_bottom: 8,
-                hexpand: true,
-            });
-            grid.attach(option, 0, 0, 1, 1);
+            // Use add_prefix/add_suffix (supported layout on GNOME 47+ / libadwaita 1.6+).
+            // Nesting a full GtkGrid in set_child() often yields an empty or non-interactive row.
+            const row = new Adw.ActionRow();
+            row.add_prefix(option);
             if (widget)
-                grid.attach(widget, 1, 0, 1, 1);
-
-            row.set_child(grid);
+                row.add_suffix(widget);
             if (widget._activatable === false)
                 row.activatable = false;
-            else
+            else if (widget)
                 row.activatable_widget = widget;
 
             group.add(row);

--- a/src/windowSwitcherPopup.js
+++ b/src/windowSwitcherPopup.js
@@ -268,54 +268,57 @@ export const WindowSwitcherPopup = {
             return false;
         this._updateInProgress = true;
 
-        this._inputHandler._remapOverlayKeyIfNeeded();
+        try {
+            this._inputHandler._remapOverlayKeyIfNeeded();
 
-        if (this._firstRun) {
-            this._pushModalCustom();
+            if (this._firstRun) {
+                this._pushModalCustom();
 
-            // Update run-time variables
-            const externalTrigger = this.CHCE_TRIGGERED !== undefined ? this.CHCE_TRIGGERED : this._externalTrigger; // backward compatibility
-            this._keyboardTriggered = this.KEYBOARD_TRIGGERED !== undefined ? this.KEYBOARD_TRIGGERED : this._keyboardTriggered; // backward compatibility
-            this._dashMode = !this._keyboardTriggered || (this._keyboardTriggered && this._overlayKeyTriggered);
-            this._positionPointer = opt.POSITION_POINTER && externalTrigger && !this._keyboardTriggered;
-            this._includeFavorites = this._dashMode ? opt.DASH_APP_INCLUDE_FAVORITES : this._includeFavorites;
-        }
+                // Update run-time variables
+                const externalTrigger = this.CHCE_TRIGGERED !== undefined ? this.CHCE_TRIGGERED : this._externalTrigger; // backward compatibility
+                this._keyboardTriggered = this.KEYBOARD_TRIGGERED !== undefined ? this.KEYBOARD_TRIGGERED : this._keyboardTriggered; // backward compatibility
+                this._dashMode = !this._keyboardTriggered || (this._keyboardTriggered && this._overlayKeyTriggered);
+                this._positionPointer = opt.POSITION_POINTER && externalTrigger && !this._keyboardTriggered;
+                this._includeFavorites = this._dashMode ? opt.DASH_APP_INCLUDE_FAVORITES : this._includeFavorites;
+            }
 
-        this._updateFilterMode();
-        this._handleSingleAppMode(binding);
-        this._storePointerPosition();
+            this._updateFilterMode();
+            this._handleSingleAppMode(binding);
+            this._storePointerPosition();
 
-        let itemList = this._getAdjustedItemList();
-        if (!itemList.length)
-            return false;
+            let itemList = this._getAdjustedItemList();
+            if (!itemList.length)
+                return false;
 
-        this._updateSwitcherList(itemList);
+            this._updateSwitcherList(itemList);
 
-        // Need to force an allocation so we can figure out whether we
-        // need to scroll when selecting
-        this.visible = true;
-        this.opacity = 0;
-        this.get_allocation_box();
+            // Need to force an allocation so we can figure out whether we
+            // need to scroll when selecting
+            this.visible = true;
+            this.opacity = 0;
+            this.get_allocation_box();
 
-        this._setInitialSelection(backward, binding);
+            this._setInitialSelection(backward, binding);
 
-        if (this._resetNoModsTimeoutOrFinish(binding, mask))
+            if (this._resetNoModsTimeoutOrFinish(binding, mask))
+                return true;
+
+            this._updateStyle();
+            this._updateCaptionLabelOpacity();
+            this._wsTmb?.remove_all_transitions();
+            this._setSwitcherStatus();
+
+            this._showPopup();
+
+            this._showSearchCaptionIfNeeded();
+
+            this._firstRun = false;
+            this._switcherList._updateMouseControls(this._mouseHoveringItemIndex);
+
             return true;
-
-        this._updateStyle();
-        this._updateCaptionLabelOpacity();
-        this._wsTmb?.remove_all_transitions();
-        this._setSwitcherStatus();
-
-        this._showPopup();
-
-        this._showSearchCaptionIfNeeded();
-
-        this._firstRun = false;
-        this._updateInProgress = false;
-        this._switcherList._updateMouseControls(this._mouseHoveringItemIndex);
-
-        return true;
+        } finally {
+            this._updateInProgress = false;
+        }
     },
 
     _pushModalCustom() {
@@ -352,17 +355,19 @@ export const WindowSwitcherPopup = {
     },
 
     _pushModal() {
-        let result = true;
-        let grab = Main.pushModal(this);
-        // We expect at least a keyboard grab here (GNOME < 50 only)
-        if (grab.get_seat_state && (grab.get_seat_state() & Clutter.GrabState.KEYBOARD) === 0) {
+        const grab = Main.pushModal(this);
+        // When the grab exposes state (Clutter: get_windowing_state or legacy get_seat_state),
+        // ensure we have a keyboard grab; otherwise assume success like upstream SwitcherPopup.
+        const state = grab.get_windowing_state?.() ?? grab.get_seat_state?.();
+        if (state !== undefined && (state & Clutter.GrabState.KEYBOARD) === 0) {
             Main.popModal(grab);
-            result = false;
+            this._grab = null;
+            this._haveModal = false;
+            return false;
         }
         this._grab = grab;
         this._haveModal = true;
-        this._haveModal = result;
-        return result;
+        return true;
     },
 
     _resetNoModsTimeoutOrFinish(binding, mask) {


### PR DESCRIPTION
- Prefer grab.get_windowing_state() with get_seat_state() fallback; avoid stale grab on failed modal
- Clear _updateInProgress in show() via try/finally so Alt+Tab cannot get stuck
- Prefs: async fillPreferencesWindow; Adw.ActionRow add_prefix/add_suffix instead of set_child grid
- Disable: remove AppSwitcherPopupInit override and reverse teardown order; fix disable log
- README: GNOME 50 Wayland notes and session restart after install/update

Per https://github.com/G-dH/advanced-alttab-window-switcher/issues/174